### PR TITLE
Updated the urls of the debian/ubuntu, fedora and openSUSE binaries

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -5,5 +5,5 @@
   channel: Stable
   released: March 8th, 2018
   stable_api_since: November 11th, 2013
-  bin_url_debian: http://codelite.org/LiteEditor/WxWidgets30Binaries#toc2
-  bin_url_fedora: http://codelite.org/LiteEditor/WxWidgets30Binaries#toc3
+  bin_url_debian: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc2
+  bin_url_fedora: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc3


### PR DESCRIPTION
The old CodeLite wiki broke last week, and the new one has a different url.

This commit corrects the links for wx3.0.4. However the wx3.1 links are also affected, but I can't see where they come from. Are they created programmatically from the wx3.0 ones?